### PR TITLE
fix: relax dependency requirement for excon

### DIFF
--- a/minitel.gemspec
+++ b/minitel.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.platform      = Gem::Platform::RUBY
   gem.license       = "MIT"
 
-  gem.add_runtime_dependency 'excon', '~> 0.20'
+  gem.add_runtime_dependency 'excon', '> 0.20'
   gem.add_runtime_dependency 'multi_json', '~> 1.0'
 
   gem.add_development_dependency 'guard', '~> 2.6'


### PR DESCRIPTION
This PR relaxes the gemspec to allow newer versions of excon.

Context:

At this time, the latest excon is 1.2.5, but the gemspec for minitel only allows 0.x versions. I've done a review and some testing and I don't see any code or issues with the newest version of excon.

